### PR TITLE
Custom release filenames in GitHub workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -48,12 +48,17 @@ jobs:
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
 
+      - name: Rename Release Files
+        run: |
+          mv build/app/outputs/bundle/release/app-release.aab build/app/outputs/bundle/release/gridwalker-${{ github.ref_name }}.aab
+          mv build/app/outputs/flutter-apk/app-release.apk build/app/outputs/flutter-apk/gridwalker-${{ github.ref_name }}.apk
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            build/app/outputs/bundle/release/app-release.aab
-            build/app/outputs/flutter-apk/app-release.apk
+            build/app/outputs/bundle/release/gridwalker-${{ github.ref_name }}.aab
+            build/app/outputs/flutter-apk/gridwalker-${{ github.ref_name }}.apk
           generate_release_notes: true
           draft: false
           prerelease: false


### PR DESCRIPTION
Updates the CI/CD pipeline to rename release artifacts (AAB/APK) with the version tag before uploading them to the GitHub Release.